### PR TITLE
В мобильной версии dropdown в GE теперь не обрезается по границе ячейки

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-flexberry-themes",
-  "version": "0.3.0-beta.8",
+  "version": "0.3.0-beta.9",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/themes/ghost/components/flexberry-groupedit.overrides
+++ b/src/themes/ghost/components/flexberry-groupedit.overrides
@@ -82,6 +82,7 @@ div:not(.groupedit-modal-content) {
         padding-top: @olvCellVerticalPadding;
         padding-bottom: @olvCellVerticalPadding;
         vertical-align: top;
+        overflow: visible;
 
         &.field .flexberry-checkbox {
           padding-top: @olvCheckboxCellVerticalPadding;


### PR DESCRIPTION
[Задача](https://gitlab.neoplatform.ru/flexberry-developers-tools/flexberry-ember/emberjs-tech/-/issues/52)